### PR TITLE
Erase unguaranteeable Sync requirement

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,7 @@ pub struct Input(Stream);
 
 impl Input {
     /// Open the input stream.
-    pub fn open(self) -> io::Result<Box<dyn Read + Sync + 'static>> {
+    pub fn open(self) -> io::Result<Box<dyn Read + 'static>> {
         match self.0 {
             Stream::File(_) => {
                 let file = self.open_file().unwrap()?;
@@ -194,7 +194,7 @@ pub struct Output(Stream);
 
 impl Output {
     /// Open the output stream.
-    pub fn open(self) -> io::Result<Box<dyn Write + Sync + 'static>> {
+    pub fn open(self) -> io::Result<Box<dyn Write + 'static>> {
         match self.0 {
             Stream::File(_) => {
                 let file = self.open_file().unwrap()?;


### PR DESCRIPTION
It seems unusual to expect an I/O stream to be "sync" after you have taken the lock (the lock being the thing that generally signifies access now occurs from that specific thread...)

See https://github.com/rust-lang/rust/issues/127340