### PR TITLE
Erase unguaranteeable sync requirement, update deprecated CI runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ on:
 jobs:
   ci:
     name: Format, lint, and test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: davidB/rust-cargo-make@v1

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Easily add a `--input` and `--output` flags to CLIs using clap
 cargo run --example copy -- --help
 ```
 
-
 ## LICENSE
 
 Copyright © 2023 Swift Navigation

--- a/examples/positional.rs
+++ b/examples/positional.rs
@@ -19,8 +19,7 @@
 
 use anyhow::Result;
 
-use clap::{Parser, CommandFactory};
-use clap_io::{Input, Output};
+use clap::Parser;
 
 macro_rules! converter {
     ($name:ident) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,7 @@ pub struct Input(Stream);
 
 impl Input {
     /// Open the input stream.
-    pub fn open(self) -> io::Result<Box<dyn Read + Sync + 'static>> {
+    pub fn open(self) -> io::Result<Box<dyn Read + 'static>> {
         match self.0 {
             Stream::File(_) => {
                 let file = self.open_file().unwrap()?;
@@ -194,7 +194,7 @@ pub struct Output(Stream);
 
 impl Output {
     /// Open the output stream.
-    pub fn open(self) -> io::Result<Box<dyn Write + Sync + 'static>> {
+    pub fn open(self) -> io::Result<Box<dyn Write + 'static>> {
         match self.0 {
             Stream::File(_) => {
                 let file = self.open_file().unwrap()?;


### PR DESCRIPTION
This PR updates deprecated ubuntu runner, and erases an unguaranteeable sync requirement 

## Related PR
* https://github.com/swift-nav/clap-io/pull/2