### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clap-io"
-version = "0.1.0"
+version = "0.1.1"
 description = "Add input and output flags to clap commands"
 authors = ["Swift Navigation <dev@swiftnav.com>"]
 edition = "2021"


### PR DESCRIPTION
Bump clap-io version after the changes in https://github.com/swift-nav/clap-io/pull/3