### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and as of v0.2.0, this project adheres to [Semantic Versioning](https://semver.o
 
 ### Breaking Changes
 
-- Removes a sync trait requierment on the wrapped inputs and outputs
+- Removes a sync trait bound on the wrapped inputs and outputs
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,12 @@ and as of v0.2.0, this project adheres to [Semantic Versioning](https://semver.o
 
 ### Fixed
 
-- Follows SemVar
+- Follows SemVer
 
 ## [0.1.1] 2024-07-25 [YANKED]
 
 NOTE: This release only existed as a git tag, and will not be posted to 
-crates.io because it did not follow SemVar.
+crates.io because it did not follow SemVer.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and as of v0.2.0, this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] 2024-09-05
+
+### Breaking Changes
+
+- Removes a sync trait requierment on the wrapped inputs and outputs
+
+### Added
+
+- CHANGELOG.md
+
+### Fixed
+
+- Follows SemVar
+
+## [0.1.1] 2024-07-25 [YANKED]
+
+NOTE: This release only existed as a git tag, and will not be posted to 
+crates.io because it did not follow SemVar.
+
+### Fixed
+
+- Removed an unguaranteeable sync requirement on the wrapped Input & Output
+
+## [0.1.0] 2023-01-12
+
+First release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clap-io"
-version = "0.1.1"
+version = "0.2.0"
 description = "Add input and output flags to clap commands"
 authors = ["Swift Navigation <dev@swiftnav.com>"]
 edition = "2021"


### PR DESCRIPTION
This PR bumps the previous tag to v0.2.0 because v0.1.1 was not following SemVar. v0.1.1 was not & will not be published to crates.io

This PR also adds a changelog